### PR TITLE
fix for perl braking change

### DIFF
--- a/03/cronjob/cronjob-km.yml
+++ b/03/cronjob/cronjob-km.yml
@@ -19,5 +19,5 @@ spec:
           containers:
           - name: cronjob-ctr
             image: perl
-            command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+            command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(1000)"]
           restartPolicy: OnFailure 


### PR DESCRIPTION
The example stopped working and was throwing error:
`Can't use an undefined value as an ARRAY reference at /usr/local/lib/perl5/5.36.0/Math/BigInt/Calc.pm line 1049.`
According to [this github issue](https://github.com/kubernetes/website/pull/34070)
this is a perl breaking change, documentation of kubernetes was updated to calculate 1000 digits